### PR TITLE
Add fursuit gallery site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Silicore Pages
 
-This repository hosts the source files for the Silicore website. Currently it contains only this README.
+This repository hosts a small static website for showcasing fursuit projects. Each suit is identified by a code (e.g., P051) and includes customer and species information.
 
 ## Getting Started
 
-Clone the repository to begin contributing:
+Open `index.html` in a web browser to view the gallery.
 
-```bash
-git clone https://github.com/example/Silicore_Pages.git
-```
+Image assets are not tracked in this repository. Add your own images under an
+`images/<ID>/` directory that matches the paths defined in
+`data/fursuits.json` to see them in the gallery.
 
 ## Contributing
 
@@ -19,4 +19,3 @@ git clone https://github.com/example/Silicore_Pages.git
 ## License
 
 No explicit license has been selected yet.
-

--- a/app.js
+++ b/app.js
@@ -1,0 +1,29 @@
+fetch('data/fursuits.json')
+  .then(response => response.json())
+  .then(data => {
+    const gallery = document.getElementById('gallery');
+    data.forEach(suit => {
+      const section = document.createElement('div');
+      section.className = 'suit';
+
+      const header = document.createElement('h2');
+      header.textContent = `${suit.id} - ${suit.customer} (${suit.species})`;
+      section.appendChild(header);
+
+      const imagesDiv = document.createElement('div');
+      imagesDiv.className = 'suit-images';
+
+      suit.images.forEach(src => {
+        const img = document.createElement('img');
+        img.src = src;
+        img.alt = `${suit.id} image`;
+        imagesDiv.appendChild(img);
+      });
+
+      section.appendChild(imagesDiv);
+      gallery.appendChild(section);
+    });
+  })
+  .catch(err => {
+    console.error('Failed to load fursuit data:', err);
+  });

--- a/data/fursuits.json
+++ b/data/fursuits.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "P051",
+    "customer": "Alice",
+    "species": "Fox",
+    "images": [
+      "images/P051/p051_1.webp",
+      "images/P051/p051_2.webp"
+    ]
+  },
+  {
+    "id": "P052",
+    "customer": "Bob",
+    "species": "Wolf",
+    "images": [
+      "images/P052/p052_1.webp"
+    ]
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Fursuit Gallery</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Fursuit Gallery</h1>
+  <div id="gallery"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,20 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 800px;
+  margin: auto;
+  padding: 1rem;
+}
+
+.suit {
+  margin-bottom: 2rem;
+}
+
+.suit h2 {
+  margin-bottom: 0.5rem;
+}
+
+.suit-images img {
+  width: 100px;
+  height: 100px;
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Add static index page and JavaScript to render fursuit gallery
- Store suit metadata and image paths in JSON
- Include placeholder WebP images and basic styling
- Remove placeholder WebP files and clarify README on adding your own images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc03587e48328ba56c17678a2d1bf